### PR TITLE
Use conversations.history api because channels.history has been deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ Following api tokens are required:
   - Bot User OAuth Access Token `https://api.slack.com/apps/~~/install-on-team`
   - Enable Events and add subscription to `reaction added` events https://api.slack.com/apps/:app/event-subscriptions
   - Permissions: `channels:history` `users:read` https://api.slack.com/apps/:app/oauth
-- `SLACK_USER_TOKEN`
-  - this is because channels.history api needs slack user token, not bot token
-  - https://api.slack.com/custom-integrations/legacy-tokens
 - `GITHUB_TOKEN`
   - https://github.com/settings/tokens
 
@@ -64,7 +61,6 @@ handler = new ReactionHandler({
   issueRepo: 'hello-ai/sandbox', // required
   reactionName: ['bug'], // default: 'issue', 'issue-assign_:assignee' etc.
   slackToken: 'bot token', // default: process.env.SLACK_TOKEN
-  slackUserToken: 'user token', // default: process.env.SLACK_USER_TOKEN
   githubToken: 'github token' // default: process.env.GITHUB_TOKEN
 })
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ class ReactionHandler {
   //   reactionName: ['issue'],  // default: ['issue', 'issue-assign-:assignee']
   //   issueRepo: 'hello-ai/sandbox',
   //   slackToken: process.env.SLACK_TOKEN,
-  //   slackUserToken: process.env.SLACK_USER_TOKEN,
   //   githubToken: process.env.GITHUB_TOKEN
   // })
   constructor(params) {
@@ -23,7 +22,6 @@ class ReactionHandler {
     this.issueRepo = params.issueRepo
     this.reactionName = params.reactionName
     this.slackToken = params.slackToken || process.env.SLACK_TOKEN
-    this.slackUserToken = params.slackUserToken || process.env.SLACK_USER_TOKEN
     this.githubToken = params.githubToken || process.env.GITHUB_TOKEN
   }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "npm test && pretty-quick --staged"
     }
   }
 }

--- a/slack-client.js
+++ b/slack-client.js
@@ -13,16 +13,14 @@ class SlackClient {
     }
   }
 
-  // channels.history api needs slack user token, not bot token
-  // https://api.slack.com/custom-integrations/legacy-tokens
   async getMessages(channel, ts, count = 1) {
-    const res = await axios.get('https://slack.com/api/channels.history', {
+    const res = await axios.get('https://slack.com/api/conversations.history', {
       params: {
         channel: channel,
         latest: ts,
-        count: count,
+        limit: count,
         inclusive: true,
-        token: this.userToken
+        token: this.token
       }
     })
 

--- a/slack-client.js
+++ b/slack-client.js
@@ -1,9 +1,8 @@
 const axios = require('axios')
 
 class SlackClient {
-  constructor(token, userToken) {
+  constructor(token) {
     this.token = token || process.env.SLACK_TOKEN
-    this.userToken = userToken || process.env.SLACK_USER_TOKEN
   }
 
   apiHeaders(token) {

--- a/test.js
+++ b/test.js
@@ -6,7 +6,7 @@ const { ReactionHandler } = require('./')
 
 function mockSlackHistory(messages) {
   nock('https://slack.com')
-    .get(/^\/api\/channels.history/)
+    .get(/^\/api\/conversations.history/)
     .reply(200, {
       ok: true,
       messages


### PR DESCRIPTION
This changes fix the following error. It's because the slack api which this library uses to get messages has been deprecated.

Make it call the newer api instead.

```js
Error: {"ok":false,"error":"method_deprecated","response_metadata":{"messages":[
"[ERROR] This method is retired and can no longer be used. Please use conversations.history instead. Learn more: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api."]
}}
```

Removed SLACK_USER_TOKEN configs. `conversations.history` api does not require it so it's not needed anymore.