### PR TITLE
Pass token through header

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ class ReactionHandler {
   }
 
   async buildIssueContent(event) {
-    const slackClient = new SlackClient(this.slackToken, this.slackUserToken)
+    const slackClient = new SlackClient(this.slackToken)
 
     const { channel, ts } = event.item
     const { messages } = await slackClient.getMessages(channel, ts, 10)
@@ -178,7 +178,7 @@ class ReactionHandler {
     const issue = await githubClient.createIssue(issueRepo, issueParams)
 
     const { channel } = event.item
-    const slackClient = new SlackClient(this.slackToken, this.slackUserToken)
+    const slackClient = new SlackClient(this.slackToken)
     const slackMessage = `<@${event.user}> ${issue.html_url}`
     await slackClient.postMessage(channel, slackMessage)
 

--- a/slack-client.js
+++ b/slack-client.js
@@ -18,9 +18,9 @@ class SlackClient {
         channel: channel,
         latest: ts,
         limit: count,
-        inclusive: true,
-        token: this.token
-      }
+        inclusive: true
+      },
+      headers: this.apiHeaders(this.token)
     })
 
     if (res.status > 300) {


### PR DESCRIPTION
I was getting an error (`{ ok: false, error: 'invalid_auth' }`) when calling `conversations.history`. 

It seems like it's no longer possible to pass it as a query parameter.
Ref: https://api.slack.com/methods/conversations.history

>Authentication token bearing required scopes. Tokens should be passed as an HTTP Authorization header or alternatively, as a POST parameter.